### PR TITLE
fix: remove System.Drawing.Common from net461 build

### DIFF
--- a/AncientMysteries/AncientMysteries.csproj
+++ b/AncientMysteries/AncientMysteries.csproj
@@ -90,7 +90,6 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Drawing.Common" Version="10.0.7" />
 		<PackageReference Include="System.Memory" Version="4.5.5" />
 		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
- remove the explicit `System.Drawing.Common` package from the `net461` mod project
- rely on the framework-provided `System.Drawing` assembly instead
- fix the `OnPush` workflow failure caused by duplicate `System.Drawing.Image` definitions

## Verification
- triggered `OnPush` via `workflow_dispatch` on this branch
- run 25773487778 passed for both jobs (`Continuous Integration` and `Description Image Build`)

## Notes
- this also means Dependabot PR #116 should not be merged, because upgrading `System.Drawing.Common` would reintroduce the broken package reference
